### PR TITLE
Feature/cod 9 create check api key function

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,4 @@ build/
 .DS_Store
 .env
 coverage
+dist

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -29,7 +29,7 @@ jobs:
         run: npm ci
 
       - name: ESLint validation
-        run: npx eslint --ignore-path .gitignore . --max-warnings 0
+        run: npx eslint --max-warnings 0
 
       - name: Check commit message length
         uses: gsactions/commit-message-checker@v1

--- a/README.md
+++ b/README.md
@@ -6,7 +6,41 @@
 npm install coders-app-api-key-authenticator
 ```
 
-## Usage
+## API
+
+### checkApiKey
+
+```ts
+checkApiKey(targetApp, appToAuthenticate);
+```
+
+#### Usage
+
+```ts
+import express from "express";
+import { checkApiKey } from "coders-app-api-key-authenticator";
+
+const app = express();
+
+app.use(checkApiKey(targetApp, appToAuthenticate));
+```
+
+Returns an Express middleware which authenticates the appToAuthenticate against the targetApp(current app) using the apiKey receives in the header "X-API-KEY".
+
+| Parameter         | Type     | Description                                                   |
+| ----------------- | -------- | ------------------------------------------------------------- |
+| targetApp         | `string` | The target application to authenticate against. (current app) |
+| appToAuthenticate | `string` | The application to be authenticated.                          |
+
+---
+
+### authenticateApp
+
+```ts
+authenticateApp(targetApp, appToAuthenticate, hashToAuthenticate);
+```
+
+#### Usage
 
 ```ts
 import { authenticateApp } from "coders-app-api-key-authenticator";
@@ -16,12 +50,6 @@ const isAuthenticated = await authenticateApp(
   appToAuthenticate,
   hashToAuthenticate
 );
-```
-
-## API
-
-```ts
-authenticateApp(targetApp, appToAuthenticate, hashToAuthenticate);
 ```
 
 Authenticates the appToAuthenticate against the targetApp using the hashToAuthenticate.

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -1,0 +1,96 @@
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+
+// src/index.ts
+var src_exports = {};
+__export(src_exports, {
+  authenticateApp: () => authenticateApp_default,
+  checkApiKey: () => checkApiKey_default
+});
+module.exports = __toCommonJS(src_exports);
+
+// src/redis/redis.ts
+var import_ioredis = __toESM(require("ioredis"), 1);
+
+// src/loadEnvironments.ts
+var import_dotenv = __toESM(require("dotenv"), 1);
+import_dotenv.default.config();
+var {
+  REDIS_HOST: host,
+  REDIS_PORT: port,
+  REDIS_PASSWORD: password
+} = process.env;
+var environment = {
+  redis: {
+    host,
+    port: +port,
+    password
+  }
+};
+
+// src/redis/redis.ts
+var {
+  redis: { host: host2, password: password2, port: port2 }
+} = environment;
+var redis = new import_ioredis.default({ host: host2, password: password2, port: port2 });
+var redis_default = redis;
+
+// src/redis/getApps/getApps.ts
+var getApps = async (targetApp) => {
+  const apps = await redis_default.get(targetApp);
+  return apps ? JSON.parse(apps) : {};
+};
+var getApps_default = getApps;
+
+// src/authenticateApp/authenticateApp.ts
+var authenticateApp = async (targetApp, appToAuthenticate, hashToAuthenticate) => {
+  const apps = await getApps_default(targetApp);
+  const hash = apps[appToAuthenticate];
+  if (!hash) {
+    return false;
+  }
+  return hash === hashToAuthenticate;
+};
+var authenticateApp_default = authenticateApp;
+
+// src/checkApiKey/checkApiKey.ts
+var checkApiKey = (targetApp, appToAuthenticate) => async (req, res, next) => {
+  const apiKeyHeader = "X-API-KEY";
+  const apiKey = req.get(apiKeyHeader);
+  try {
+    if (!await authenticateApp_default(targetApp, appToAuthenticate, apiKey)) {
+      throw new Error("Invalid API key");
+    }
+    next();
+  } catch (error) {
+    error.statusCode = 401;
+    next(error);
+  }
+};
+var checkApiKey_default = checkApiKey;
+// Annotate the CommonJS export names for ESM import in node:
+0 && (module.exports = {
+  authenticateApp,
+  checkApiKey
+});

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,0 +1,14 @@
+import { Request, Response, NextFunction } from "express";
+
+declare const authenticateApp: (
+  targetApp: string,
+  appToAuthenticate: string,
+  hashToAuthenticate: string
+) => Promise<boolean>;
+
+declare const checkApiKey: (
+  targetApp: string,
+  appToAuthenticate: string
+) => (req: Request, res: Response, next: NextFunction) => Promise<void>;
+
+export { authenticateApp, checkApiKey };

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,69 @@
+// src/redis/redis.ts
+import Redis from "ioredis";
+
+// src/loadEnvironments.ts
+import dotenv from "dotenv";
+dotenv.config();
+var {
+  REDIS_HOST: host,
+  REDIS_PORT: port,
+  REDIS_PASSWORD: password,
+} = process.env;
+var environment = {
+  redis: {
+    host,
+    port: +port,
+    password,
+  },
+};
+
+// src/redis/redis.ts
+var {
+  redis: { host: host2, password: password2, port: port2 },
+} = environment;
+var redis = new Redis({ host: host2, password: password2, port: port2 });
+var redis_default = redis;
+
+// src/redis/getApps/getApps.ts
+var getApps = async (targetApp) => {
+  const apps = await redis_default.get(targetApp);
+  return apps ? JSON.parse(apps) : {};
+};
+var getApps_default = getApps;
+
+// src/authenticateApp/authenticateApp.ts
+var authenticateApp = async (
+  targetApp,
+  appToAuthenticate,
+  hashToAuthenticate
+) => {
+  const apps = await getApps_default(targetApp);
+  const hash = apps[appToAuthenticate];
+  if (!hash) {
+    return false;
+  }
+  return hash === hashToAuthenticate;
+};
+var authenticateApp_default = authenticateApp;
+
+// src/checkApiKey/checkApiKey.ts
+var checkApiKey = (targetApp, appToAuthenticate) => async (req, res, next) => {
+  const apiKeyHeader = "X-API-KEY";
+  const apiKey = req.get(apiKeyHeader);
+  try {
+    if (
+      !(await authenticateApp_default(targetApp, appToAuthenticate, apiKey))
+    ) {
+      throw new Error("Invalid API key");
+    }
+    next();
+  } catch (error) {
+    error.statusCode = 401;
+    next(error);
+  }
+};
+var checkApiKey_default = checkApiKey;
+export {
+  authenticateApp_default as authenticateApp,
+  checkApiKey_default as checkApiKey,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "coders-app-api-key-authenticator",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "coders-app-api-key-authenticator",
-      "version": "1.0.0",
+      "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
         "dotenv": "^16.0.3",
         "ioredis": "^5.2.5"
       },
       "devDependencies": {
+        "@types/express": "^4.17.16",
         "@types/jest": "^29.2.6",
         "@typescript-eslint/eslint-plugin": "^5.42.0",
         "@typescript-eslint/parser": "^5.42.0",
@@ -1262,6 +1263,48 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+      "dev": true,
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.16",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.16.tgz",
+      "integrity": "sha512-LkKpqRZ7zqXJuvoELakaFYuETHjZkSol8EV6cNnyishutDBCCdv6+dsKPbKkCcIk57qRphOLY5sEgClw1bO3gA==",
+      "dev": true,
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.31",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.17.33",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.33.tgz",
+      "integrity": "sha512-TPBqmR/HRYI3eC2E5hmiivIzv+bidAfXofM+sbonAGvyDhySGw9/PQZFt2BLOrjUUR++4eJVpx6KnLQK1Fk9tA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -1311,6 +1354,12 @@
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
     },
+    "node_modules/@types/mime": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
+      "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
+      "dev": true
+    },
     "node_modules/@types/node": {
       "version": "18.11.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
@@ -1323,11 +1372,33 @@
       "integrity": "sha512-ri0UmynRRvZiiUJdiz38MmIblKK+oH30MztdBVR95dv/Ubw6neWSb8u1XpRb72L4qsZOhz+L+z9JD40SJmfWow==",
       "dev": true
     },
+    "node_modules/@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+      "dev": true
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+      "dev": true
+    },
     "node_modules/@types/semver": {
       "version": "7.3.13",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
       "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
       "dev": true
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.0.tgz",
+      "integrity": "sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==",
+      "dev": true,
+      "dependencies": {
+        "@types/mime": "*",
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
@@ -7251,6 +7322,48 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/body-parser": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+      "dev": true,
+      "requires": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/express": {
+      "version": "4.17.16",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.16.tgz",
+      "integrity": "sha512-LkKpqRZ7zqXJuvoELakaFYuETHjZkSol8EV6cNnyishutDBCCdv6+dsKPbKkCcIk57qRphOLY5sEgClw1bO3gA==",
+      "dev": true,
+      "requires": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.31",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "@types/express-serve-static-core": {
+      "version": "4.17.33",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.33.tgz",
+      "integrity": "sha512-TPBqmR/HRYI3eC2E5hmiivIzv+bidAfXofM+sbonAGvyDhySGw9/PQZFt2BLOrjUUR++4eJVpx6KnLQK1Fk9tA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
+    },
     "@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -7300,6 +7413,12 @@
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
     },
+    "@types/mime": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
+      "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
+      "dev": true
+    },
     "@types/node": {
       "version": "18.11.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
@@ -7312,11 +7431,33 @@
       "integrity": "sha512-ri0UmynRRvZiiUJdiz38MmIblKK+oH30MztdBVR95dv/Ubw6neWSb8u1XpRb72L4qsZOhz+L+z9JD40SJmfWow==",
       "dev": true
     },
+    "@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+      "dev": true
+    },
+    "@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+      "dev": true
+    },
     "@types/semver": {
       "version": "7.3.13",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
       "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
       "dev": true
+    },
+    "@types/serve-static": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.0.tgz",
+      "integrity": "sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==",
+      "dev": true,
+      "requires": {
+        "@types/mime": "*",
+        "@types/node": "*"
+      }
     },
     "@types/stack-utils": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "@types/express": "^4.17.16",
     "@types/jest": "^29.2.6",
     "@typescript-eslint/eslint-plugin": "^5.42.0",
     "@typescript-eslint/parser": "^5.42.0",

--- a/src/checkApiKey/checkApiKey.test.ts
+++ b/src/checkApiKey/checkApiKey.test.ts
@@ -1,12 +1,14 @@
 import type { Request, NextFunction } from "express";
 import checkApiKey from "./checkApiKey";
 import appNames from "../utils/appNames";
+import type { CustomError } from "../types";
 
 const { apiGateway, identityServer } = appNames;
 
 const headers: Record<string, string> = {
   "X-API-KEY": "hash",
 };
+
 const req: Partial<Request> = {
   headers,
 
@@ -15,14 +17,31 @@ const req: Partial<Request> = {
 
 const next: NextFunction = jest.fn();
 
-describe("Given the middleware returned from checkApiKey invoked with targetApp 'api-gateway' and appToAuthenticate 'identity-server'", () => {
-  const checkApiKeyMiddleware = checkApiKey(apiGateway, identityServer);
+afterEach(() => jest.clearAllMocks());
 
+describe("Given the middleware returned from checkApiKey invoked with targetApp 'api-gateway' and appToAuthenticate 'identity-server'", () => {
   describe("When it receives a request with header X-API-KEY 'hash'", () => {
     test("Then it should invoke next with no parameters", async () => {
+      const checkApiKeyMiddleware = checkApiKey(apiGateway, identityServer);
+
       await checkApiKeyMiddleware(req as Request, null, next);
 
       expect(next).toHaveBeenCalled();
+    });
+  });
+});
+
+describe("Given the middleware returned from checkApiKey invoked with targetApp 'identity-server' and appToAuthenticate 'api-gateway'", () => {
+  describe("When it receives a request with header X-API-KEY 'hash'", () => {
+    test("Then it should invoke next with an error with message 'Invalid API key' and statusCode 401", async () => {
+      const checkApiKeyMiddleware = checkApiKey(identityServer, apiGateway);
+      const invalidKeyMessage = "Invalid API key";
+      const invalidKeyError = new Error(invalidKeyMessage);
+      (invalidKeyError as CustomError).statusCode = 401;
+
+      await checkApiKeyMiddleware(req as Request, null, next);
+
+      expect(next).toHaveBeenCalledWith(invalidKeyError);
     });
   });
 });

--- a/src/checkApiKey/checkApiKey.test.ts
+++ b/src/checkApiKey/checkApiKey.test.ts
@@ -1,0 +1,28 @@
+import type { Request, NextFunction } from "express";
+import checkApiKey from "./checkApiKey";
+import appNames from "../utils/appNames";
+
+const { apiGateway, identityServer } = appNames;
+
+const headers: Record<string, string> = {
+  "X-API-KEY": "hash",
+};
+const req: Partial<Request> = {
+  headers,
+
+  get: jest.fn().mockImplementation((name: string) => headers[name]),
+};
+
+const next: NextFunction = jest.fn();
+
+describe("Given the middleware returned from checkApiKey invoked with targetApp 'api-gateway' and appToAuthenticate 'identity-server'", () => {
+  const checkApiKeyMiddleware = checkApiKey(apiGateway, identityServer);
+
+  describe("When it receives a request with header X-API-KEY 'hash'", () => {
+    test("Then it should invoke next with no parameters", async () => {
+      await checkApiKeyMiddleware(req as Request, null, next);
+
+      expect(next).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/checkApiKey/checkApiKey.ts
+++ b/src/checkApiKey/checkApiKey.ts
@@ -1,0 +1,24 @@
+import type { Request, Response, NextFunction } from "express";
+import authenticateApp from "../authenticateApp";
+import type { CustomError } from "../types";
+
+const checkApiKey =
+  (targetApp: string, appToAuthenticate: string) =>
+  async (req: Request, res: Response, next: NextFunction) => {
+    const apiKeyHeader = "X-API-KEY";
+    const apiKey = req.get(apiKeyHeader);
+
+    try {
+      if (!(await authenticateApp(targetApp, appToAuthenticate, apiKey))) {
+        throw new Error("Invalid API key");
+      }
+
+      next();
+    } catch (error: unknown) {
+      (error as CustomError).statusCode = 401;
+
+      next(error);
+    }
+  };
+
+export default checkApiKey;

--- a/src/checkApiKey/index.ts
+++ b/src/checkApiKey/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./checkApiKey";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { default as authenticateApp } from "./authenticateApp";
+export { default as checkApiKey } from "./checkApiKey";

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,3 @@
+export interface CustomError extends Error {
+  statusCode: number;
+}


### PR DESCRIPTION
He creado la funcion `checkApiKey`, lo cual devuelve un middleware de Express que podemos usar para autenticar api keys. 
He actualizado el readme para incluir la nueva función. 

@coders-app/devs He pensado que podría subir la carpeta `dist` temporalmente y podríamos importar esta función en las APIs con el repo de Github en vez que por NPM. Que opináis? 