### PR TITLE
Bugfix/cod 82 add hash compare to authenticate app

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,11 @@
+src
+.github
+husky
+.editorconfig
+.eslintrc.cjs
+.eslintignore
+.lintstagedrc.json
+jest.config.cjs
+sonar-project.properties
+tsconfig.json
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Returns an Express middleware which authenticates the appToAuthenticate against 
 ### authenticateApp
 
 ```ts
-authenticateApp(targetApp, appToAuthenticate, hashToAuthenticate);
+authenticateApp(targetApp, appToAuthenticate, keyToAuthenticate);
 ```
 
 #### Usage
@@ -48,18 +48,18 @@ import { authenticateApp } from "coders-app-api-key-authenticator";
 const isAuthenticated = await authenticateApp(
   targetApp,
   appToAuthenticate,
-  hashToAuthenticate
+  keyToAuthenticate
 );
 ```
 
-Authenticates the appToAuthenticate against the targetApp using the hashToAuthenticate.
+Authenticates the appToAuthenticate against the targetApp using the keyToAuthenticate.
 
 Returns a promise that resolves to a boolean indicating whether the application is authenticated or not.
 | Parameter | Type | Description |
 | --- | --- | --- |
 | targetApp | `string` | The target application to authenticate against. (current app) |
 | appToAuthenticate | `string` | The application to be authenticated. |
-| hashToAuthenticate | `string` | The hash used to authenticate the application. |
+| keyToAuthenticate | `string` | The key used to authenticate the application. |
 
 ## Env
 

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -1,3 +1,4 @@
+"use strict";
 var __create = Object.create;
 var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
@@ -64,13 +65,14 @@ var getApps = async (targetApp) => {
 var getApps_default = getApps;
 
 // src/authenticateApp/authenticateApp.ts
-var authenticateApp = async (targetApp, appToAuthenticate, hashToAuthenticate) => {
+var import_bcryptjs = __toESM(require("bcryptjs"), 1);
+var authenticateApp = async (targetApp, appToAuthenticate, keyToAuthenticate) => {
   const apps = await getApps_default(targetApp);
   const hash = apps[appToAuthenticate];
   if (!hash) {
     return false;
   }
-  return hash === hashToAuthenticate;
+  return import_bcryptjs.default.compare(keyToAuthenticate, hash);
 };
 var authenticateApp_default = authenticateApp;
 

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -3,7 +3,7 @@ import { Request, Response, NextFunction } from "express";
 declare const authenticateApp: (
   targetApp: string,
   appToAuthenticate: string,
-  hashToAuthenticate: string
+  keyToAuthenticate: string
 ) => Promise<boolean>;
 
 declare const checkApiKey: (

--- a/dist/index.js
+++ b/dist/index.js
@@ -32,17 +32,18 @@ var getApps = async (targetApp) => {
 var getApps_default = getApps;
 
 // src/authenticateApp/authenticateApp.ts
+import bcrypt from "bcryptjs";
 var authenticateApp = async (
   targetApp,
   appToAuthenticate,
-  hashToAuthenticate
+  keyToAuthenticate
 ) => {
   const apps = await getApps_default(targetApp);
   const hash = apps[appToAuthenticate];
   if (!hash) {
     return false;
   }
-  return hash === hashToAuthenticate;
+  return bcrypt.compare(keyToAuthenticate, hash);
 };
 var authenticateApp_default = authenticateApp;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
+        "bcryptjs": "^2.4.3",
         "dotenv": "^16.0.3",
         "ioredis": "^5.2.5"
       },
       "devDependencies": {
+        "@types/bcryptjs": "^2.4.2",
         "@types/express": "^4.17.16",
         "@types/jest": "^29.2.6",
         "@typescript-eslint/eslint-plugin": "^5.42.0",
@@ -1263,6 +1265,12 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/bcryptjs": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.2.tgz",
+      "integrity": "sha512-LiMQ6EOPob/4yUL66SZzu6Yh77cbzJFYll+ZfaPiPPFswtIlA/Fs1MzdKYA7JApHU49zQTbJGX3PDmCpIdDBRQ==",
+      "dev": true
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
@@ -1854,6 +1862,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ=="
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -7322,6 +7335,12 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/bcryptjs": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.2.tgz",
+      "integrity": "sha512-LiMQ6EOPob/4yUL66SZzu6Yh77cbzJFYll+ZfaPiPPFswtIlA/Fs1MzdKYA7JApHU49zQTbJGX3PDmCpIdDBRQ==",
+      "dev": true
+    },
     "@types/body-parser": {
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
@@ -7760,6 +7779,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ=="
     },
     "binary-extensions": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,6 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "type": "module",
-  "files": [
-    "dist"
-  ],
   "scripts": {
     "build": "tsup src/index.ts --format cjs,esm --dts",
     "build:full": "tsc",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "@types/bcryptjs": "^2.4.2",
     "@types/express": "^4.17.16",
     "@types/jest": "^29.2.6",
     "@typescript-eslint/eslint-plugin": "^5.42.0",
@@ -40,6 +41,7 @@
     "typescript": "^4.8.4"
   },
   "dependencies": {
+    "bcryptjs": "^2.4.3",
     "dotenv": "^16.0.3",
     "ioredis": "^5.2.5"
   }

--- a/src/authenticateApp/authenticateApp.test.ts
+++ b/src/authenticateApp/authenticateApp.test.ts
@@ -4,30 +4,30 @@ import authenticateApp from "./authenticateApp.js";
 const { apiGateway, identityServer } = appNames;
 
 describe("Given the function authenticateApp", () => {
-  const testHash = "hash";
+  const testKey = "key";
 
-  describe("When it receives targetApp 'api-gateway', appToAuthenticate 'identity-server' and hashToAuthenticate 'hash'", () => {
+  describe("When it receives targetApp 'api-gateway', appToAuthenticate 'identity-server' and keyToAuthenticate 'key' and the key is correct", () => {
     test("Then it should return true", async () => {
       const isAuthenticatedResult = true;
 
       const isAuthenticated = await authenticateApp(
         apiGateway,
         identityServer,
-        testHash
+        testKey
       );
 
       expect(isAuthenticated).toBe(isAuthenticatedResult);
     });
   });
 
-  describe("When it receives targetApp 'identity-server', appToAuthenticate 'api-gateway' and hashToAuthenticate 'hash'", () => {
+  describe("When it receives targetApp 'identity-server', appToAuthenticate 'api-gateway' and keyToAuthenticate 'bad-key' and the key is incorrect", () => {
     test("Then it should return false", async () => {
       const isAuthenticatedResult = false;
 
       const isAuthenticated = await authenticateApp(
         identityServer,
         apiGateway,
-        testHash
+        testKey
       );
 
       expect(isAuthenticated).toBe(isAuthenticatedResult);

--- a/src/authenticateApp/authenticateApp.ts
+++ b/src/authenticateApp/authenticateApp.ts
@@ -1,9 +1,10 @@
 import getApps from "../redis/getApps/getApps.js";
+import bcrypt from "bcryptjs";
 
 const authenticateApp = async (
   targetApp: string,
   appToAuthenticate: string,
-  hashToAuthenticate: string
+  keyToAuthenticate: string
 ): Promise<boolean> => {
   const apps = await getApps(targetApp);
 
@@ -13,7 +14,7 @@ const authenticateApp = async (
     return false;
   }
 
-  return hash === hashToAuthenticate;
+  return bcrypt.compare(keyToAuthenticate, hash);
 };
 
 export default authenticateApp;

--- a/src/checkApiKey/checkApiKey.test.ts
+++ b/src/checkApiKey/checkApiKey.test.ts
@@ -1,4 +1,4 @@
-import type { Request, NextFunction } from "express";
+import type { Request, NextFunction, Response } from "express";
 import checkApiKey from "./checkApiKey";
 import appNames from "../utils/appNames";
 import type { CustomError } from "../types";
@@ -6,7 +6,7 @@ import type { CustomError } from "../types";
 const { apiGateway, identityServer } = appNames;
 
 const headers: Record<string, string> = {
-  "X-API-KEY": "hash",
+  "X-API-KEY": "key",
 };
 
 const req: Partial<Request> = {
@@ -20,11 +20,11 @@ const next: NextFunction = jest.fn();
 afterEach(() => jest.clearAllMocks());
 
 describe("Given the middleware returned from checkApiKey invoked with targetApp 'api-gateway' and appToAuthenticate 'identity-server'", () => {
-  describe("When it receives a request with header X-API-KEY 'hash'", () => {
+  describe("When it receives a request with header X-API-KEY 'key'", () => {
     test("Then it should invoke next with no parameters", async () => {
       const checkApiKeyMiddleware = checkApiKey(apiGateway, identityServer);
 
-      await checkApiKeyMiddleware(req as Request, null, next);
+      await checkApiKeyMiddleware(req as Request, {} as Response, next);
 
       expect(next).toHaveBeenCalled();
     });
@@ -32,14 +32,14 @@ describe("Given the middleware returned from checkApiKey invoked with targetApp 
 });
 
 describe("Given the middleware returned from checkApiKey invoked with targetApp 'identity-server' and appToAuthenticate 'api-gateway'", () => {
-  describe("When it receives a request with header X-API-KEY 'hash'", () => {
+  describe("When it receives a request with header X-API-KEY 'key'", () => {
     test("Then it should invoke next with an error with message 'Invalid API key' and statusCode 401", async () => {
       const checkApiKeyMiddleware = checkApiKey(identityServer, apiGateway);
       const invalidKeyMessage = "Invalid API key";
       const invalidKeyError = new Error(invalidKeyMessage);
       (invalidKeyError as CustomError).statusCode = 401;
 
-      await checkApiKeyMiddleware(req as Request, null, next);
+      await checkApiKeyMiddleware(req as Request, {} as Response, next);
 
       expect(next).toHaveBeenCalledWith(invalidKeyError);
     });

--- a/src/checkApiKey/checkApiKey.ts
+++ b/src/checkApiKey/checkApiKey.ts
@@ -9,7 +9,7 @@ const checkApiKey =
     const apiKey = req.get(apiKeyHeader);
 
     try {
-      if (!(await authenticateApp(targetApp, appToAuthenticate, apiKey))) {
+      if (!(await authenticateApp(targetApp, appToAuthenticate, apiKey!))) {
         throw new Error("Invalid API key");
       }
 

--- a/src/loadEnvironments.ts
+++ b/src/loadEnvironments.ts
@@ -11,7 +11,7 @@ const {
 export const environment = {
   redis: {
     host,
-    port: +port,
+    port: +port!,
     password,
   },
 };

--- a/src/redis/getApps/getApps.test.ts
+++ b/src/redis/getApps/getApps.test.ts
@@ -1,12 +1,13 @@
 import getApps from "./getApps.js";
 import appNames from "../../utils/appNames.js";
+import { hashedKey } from "../../setupTests.js";
 
 const { apiGateway, identityServer } = appNames;
 
 describe("Given the function getApps", () => {
   describe("When it receives the targetApp 'api-gateway' ", () => {
     test("Then it should return 'identity-server' and its hash", async () => {
-      const expectedApps = { [identityServer]: "hash" };
+      const expectedApps = { [identityServer]: hashedKey };
 
       const receivedApps = await getApps(apiGateway);
 

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,4 +1,7 @@
 import appNames from "./utils/appNames.js";
+import bcrypt from "bcryptjs";
+
+export const hashedKey = bcrypt.hashSync("key", 10);
 
 const { apiGateway, identityServer } = appNames;
 
@@ -6,8 +9,10 @@ const mockGet: (targetApp: string) => string = jest
   .fn()
   .mockImplementation((targetApp: string): string => {
     if (targetApp === apiGateway) {
-      return JSON.stringify({ [identityServer]: "hash" });
+      return JSON.stringify({ [identityServer]: hashedKey });
     }
+
+    return "";
   });
 
 jest.mock("./redis/redis.js", () => ({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "outDir": "./build/" /* Specify an output folder for all emitted files. */,
     "noEmitOnError": true /* Disable emitting files if any type checking errors are reported. */,
     "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
-    "noImplicitAny": true /* Enable error reporting for expressions and declarations with an implied `any` type.. */
+    "noImplicitAny": true /* Enable error reporting for expressions and declarations with an implied `any` type.. */,
+    "strict": true
   },
   "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
Antes el middleware esperaba un hash y lo comparaba con el hash en Redis.

Ahora espera la key sin hashear, y lo compara con el hash guardada en Redis utilizando bcrypt.compare