### PR TITLE
Fix ioredis imports for package consumers using Jest

### DIFF
--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -31,7 +31,7 @@ __export(src_exports, {
 module.exports = __toCommonJS(src_exports);
 
 // src/redis/redis.ts
-var import_ioredis = __toESM(require("ioredis"), 1);
+var ioredis = __toESM(require("ioredis"), 1);
 
 // src/loadEnvironments.ts
 var import_dotenv = __toESM(require("dotenv"), 1);
@@ -50,10 +50,11 @@ var environment = {
 };
 
 // src/redis/redis.ts
+var { default: Redis } = ioredis;
 var {
   redis: { host: host2, password: password2, port: port2 }
 } = environment;
-var redis = new import_ioredis.default({ host: host2, password: password2, port: port2 });
+var redis = new Redis({ host: host2, password: password2, port: port2 });
 var redis_default = redis;
 
 // src/redis/getApps/getApps.ts

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,5 +1,5 @@
 // src/redis/redis.ts
-import Redis from "ioredis";
+import * as ioredis from "ioredis";
 
 // src/loadEnvironments.ts
 import dotenv from "dotenv";
@@ -7,19 +7,20 @@ dotenv.config();
 var {
   REDIS_HOST: host,
   REDIS_PORT: port,
-  REDIS_PASSWORD: password
+  REDIS_PASSWORD: password,
 } = process.env;
 var environment = {
   redis: {
     host,
     port: +port,
-    password
-  }
+    password,
+  },
 };
 
 // src/redis/redis.ts
+var { default: Redis } = ioredis;
 var {
-  redis: { host: host2, password: password2, port: port2 }
+  redis: { host: host2, password: password2, port: port2 },
 } = environment;
 var redis = new Redis({ host: host2, password: password2, port: port2 });
 var redis_default = redis;
@@ -33,7 +34,11 @@ var getApps_default = getApps;
 
 // src/authenticateApp/authenticateApp.ts
 import bcrypt from "bcryptjs";
-var authenticateApp = async (targetApp, appToAuthenticate, keyToAuthenticate) => {
+var authenticateApp = async (
+  targetApp,
+  appToAuthenticate,
+  keyToAuthenticate
+) => {
   const apps = await getApps_default(targetApp);
   const hash = apps[appToAuthenticate];
   if (!hash) {
@@ -48,7 +53,9 @@ var checkApiKey = (targetApp, appToAuthenticate) => async (req, res, next) => {
   const apiKeyHeader = "X-API-KEY";
   const apiKey = req.get(apiKeyHeader);
   try {
-    if (!await authenticateApp_default(targetApp, appToAuthenticate, apiKey)) {
+    if (
+      !(await authenticateApp_default(targetApp, appToAuthenticate, apiKey))
+    ) {
       throw new Error("Invalid API key");
     }
     next();
@@ -60,5 +67,5 @@ var checkApiKey = (targetApp, appToAuthenticate) => async (req, res, next) => {
 var checkApiKey_default = checkApiKey;
 export {
   authenticateApp_default as authenticateApp,
-  checkApiKey_default as checkApiKey
+  checkApiKey_default as checkApiKey,
 };

--- a/src/redis/redis.ts
+++ b/src/redis/redis.ts
@@ -1,5 +1,8 @@
-import Redis from "ioredis";
+import * as ioredis from "ioredis";
 import { environment } from "../loadEnvironments.js";
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const { default: Redis } = ioredis;
 
 const {
   redis: { host, password, port },


### PR DESCRIPTION
@coders-app/devs 

Resumen de los cambios:

Hemos cambiado la forma de importar la clase `Redis` de `ioredis`

La forma anterior: 

```
import Redis from "ioredis";
```

Este causaba errores cuando un consimidor del paquete usa Jest para testear. 
Da un Syntax error porque no puede leer el import

La forma nueva: 

```
import * as ioredis from "ioredis";

const { default: Redis } = ioredis;

```

Esta forma recoge todas las exports de ioredis en el objeto `ioredis`
Podemos acceder a la propiedad default (el export default de ioredis) y cambiarle el nombre a `Redis`

Ahora consumidores del paquete no tendran el syntax error de Jest