### PR TITLE
Fix main and exports in package json because there is no mjs in bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,14 +2,14 @@
   "name": "coders-app-api-key-authenticator",
   "version": "0.0.1",
   "description": "An API key authenticator for apps in Coders App",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
-      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     }
   },


### PR DESCRIPTION
@coders-app/devs Este fix es un fix anterior que no fue implementado del todo bien. Seguiamos con .mjs en el package.json y ahora lo he quitado.

Resumen de los ultimos cambios en este repo:

El main es commonjs
Module es esm
Exports cambia el modulo que exportamos segun el sintaxis
Require es commonjs
Import es esm
