### PR TITLE
Feature/cod 107 change check api key implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ npm install coders-app-api-key-authenticator
 ### checkApiKey
 
 ```ts
-checkApiKey(targetApp, appToAuthenticate);
+checkApiKey(targetApp);
 ```
 
 #### Usage
@@ -22,22 +22,21 @@ import { checkApiKey } from "coders-app-api-key-authenticator";
 
 const app = express();
 
-app.use(checkApiKey(targetApp, appToAuthenticate));
+app.use(checkApiKey(targetApp));
 ```
 
 Returns an Express middleware which authenticates the appToAuthenticate against the targetApp(current app) using the apiKey receives in the header "X-API-KEY".
 
-| Parameter         | Type     | Description                                                   |
-| ----------------- | -------- | ------------------------------------------------------------- |
-| targetApp         | `string` | The target application to authenticate against. (current app) |
-| appToAuthenticate | `string` | The application to be authenticated.                          |
+| Parameter | Type     | Description                                                   |
+| --------- | -------- | ------------------------------------------------------------- |
+| targetApp | `string` | The target application to authenticate against. (current app) |
 
 ---
 
 ### authenticateApp
 
 ```ts
-authenticateApp(targetApp, appToAuthenticate, keyToAuthenticate);
+authenticateApp(targetApp, keyToAuthenticate);
 ```
 
 #### Usage
@@ -45,11 +44,7 @@ authenticateApp(targetApp, appToAuthenticate, keyToAuthenticate);
 ```ts
 import { authenticateApp } from "coders-app-api-key-authenticator";
 
-const isAuthenticated = await authenticateApp(
-  targetApp,
-  appToAuthenticate,
-  keyToAuthenticate
-);
+const isAuthenticated = await authenticateApp(targetApp, keyToAuthenticate);
 ```
 
 Authenticates the appToAuthenticate against the targetApp using the keyToAuthenticate.
@@ -58,7 +53,6 @@ Returns a promise that resolves to a boolean indicating whether the application 
 | Parameter | Type | Description |
 | --- | --- | --- |
 | targetApp | `string` | The target application to authenticate against. (current app) |
-| appToAuthenticate | `string` | The application to be authenticated. |
 | keyToAuthenticate | `string` | The key used to authenticate the application. |
 
 ## Env

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,7 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 
-declare const authenticateApp: (targetApp: string, appToAuthenticate: string, keyToAuthenticate: string) => Promise<boolean>;
+declare const authenticateApp: (targetApp: string, keyToAuthenticate: string) => Promise<boolean>;
 
-declare const checkApiKey: (targetApp: string, appToAuthenticate: string) => (req: Request, res: Response, next: NextFunction) => Promise<void>;
+declare const checkApiKey: (targetApp: string) => (req: Request, res: Response, next: NextFunction) => Promise<void>;
 
 export { authenticateApp, checkApiKey };

--- a/src/authenticateApp/authenticateApp.test.ts
+++ b/src/authenticateApp/authenticateApp.test.ts
@@ -6,29 +6,21 @@ const { apiGateway, identityServer } = appNames;
 describe("Given the function authenticateApp", () => {
   const testKey = "key";
 
-  describe("When it receives targetApp 'api-gateway', appToAuthenticate 'identity-server' and keyToAuthenticate 'key' and the key is correct", () => {
+  describe("When it receives targetApp 'api-gateway' and keyToAuthenticate 'key' and the key is correct", () => {
     test("Then it should return true", async () => {
       const isAuthenticatedResult = true;
 
-      const isAuthenticated = await authenticateApp(
-        apiGateway,
-        identityServer,
-        testKey
-      );
+      const isAuthenticated = await authenticateApp(apiGateway, testKey);
 
       expect(isAuthenticated).toBe(isAuthenticatedResult);
     });
   });
 
-  describe("When it receives targetApp 'identity-server', appToAuthenticate 'api-gateway' and keyToAuthenticate 'bad-key' and the key is incorrect", () => {
+  describe("When it receives targetApp 'identity-server' and keyToAuthenticate 'bad-key' and the key is incorrect", () => {
     test("Then it should return false", async () => {
       const isAuthenticatedResult = false;
 
-      const isAuthenticated = await authenticateApp(
-        identityServer,
-        apiGateway,
-        testKey
-      );
+      const isAuthenticated = await authenticateApp(identityServer, testKey);
 
       expect(isAuthenticated).toBe(isAuthenticatedResult);
     });

--- a/src/authenticateApp/authenticateApp.ts
+++ b/src/authenticateApp/authenticateApp.ts
@@ -3,18 +3,21 @@ import bcrypt from "bcryptjs";
 
 const authenticateApp = async (
   targetApp: string,
-  appToAuthenticate: string,
   keyToAuthenticate: string
 ): Promise<boolean> => {
   const apps = await getApps(targetApp);
 
-  const hash = apps[appToAuthenticate];
+  const hashes = Object.values(apps);
 
-  if (!hash) {
+  if (!hashes.length) {
     return false;
   }
 
-  return bcrypt.compare(keyToAuthenticate, hash);
+  const hashComparisons = hashes.map(async (hash) =>
+    bcrypt.compare(keyToAuthenticate, hash)
+  );
+
+  return (await Promise.all(hashComparisons)).includes(true);
 };
 
 export default authenticateApp;

--- a/src/checkApiKey/checkApiKey.test.ts
+++ b/src/checkApiKey/checkApiKey.test.ts
@@ -19,10 +19,10 @@ const next: NextFunction = jest.fn();
 
 afterEach(() => jest.clearAllMocks());
 
-describe("Given the middleware returned from checkApiKey invoked with targetApp 'api-gateway' and appToAuthenticate 'identity-server'", () => {
+describe("Given the middleware returned from checkApiKey invoked with targetApp 'api-gateway'", () => {
   describe("When it receives a request with header X-API-KEY 'key'", () => {
     test("Then it should invoke next with no parameters", async () => {
-      const checkApiKeyMiddleware = checkApiKey(apiGateway, identityServer);
+      const checkApiKeyMiddleware = checkApiKey(apiGateway);
 
       await checkApiKeyMiddleware(req as Request, {} as Response, next);
 
@@ -31,11 +31,11 @@ describe("Given the middleware returned from checkApiKey invoked with targetApp 
   });
 });
 
-describe("Given the middleware returned from checkApiKey invoked with targetApp 'identity-server' and appToAuthenticate 'api-gateway'", () => {
+describe("Given the middleware returned from checkApiKey invoked with targetApp 'identity-server'", () => {
   describe("When it receives a request with header X-API-KEY 'key'", () => {
     test("Then it should invoke next with an error with message 'Invalid API key' and statusCode 401", async () => {
-      const checkApiKeyMiddleware = checkApiKey(identityServer, apiGateway);
-      const invalidKeyMessage = "Invalid API key";
+      const checkApiKeyMiddleware = checkApiKey(identityServer);
+      const invalidKeyMessage = "Invalid API Key";
       const invalidKeyError = new Error(invalidKeyMessage);
       (invalidKeyError as CustomError).statusCode = 401;
 

--- a/src/checkApiKey/checkApiKey.ts
+++ b/src/checkApiKey/checkApiKey.ts
@@ -3,19 +3,20 @@ import authenticateApp from "../authenticateApp";
 import type { CustomError } from "../types";
 
 const checkApiKey =
-  (targetApp: string, appToAuthenticate: string) =>
+  (targetApp: string) =>
   async (req: Request, res: Response, next: NextFunction) => {
     const apiKeyHeader = "X-API-KEY";
     const apiKey = req.get(apiKeyHeader);
 
     try {
-      if (!(await authenticateApp(targetApp, appToAuthenticate, apiKey!))) {
-        throw new Error("Invalid API key");
+      if (!(await authenticateApp(targetApp, apiKey))) {
+        throw new Error("Invalid API Key");
       }
 
       next();
     } catch (error: unknown) {
       (error as CustomError).statusCode = 401;
+      (error as CustomError).publicMessage = "Invalid API Key";
 
       next(error);
     }

--- a/src/loadEnvironments.ts
+++ b/src/loadEnvironments.ts
@@ -11,7 +11,7 @@ const {
 export const environment = {
   redis: {
     host,
-    port: +port!,
+    port: +port,
     password,
   },
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
 export interface CustomError extends Error {
   statusCode: number;
+  publicMessage: string;
 }


### PR DESCRIPTION
Este es un proposal para implementar los cambios mencionados en [este comentario](https://github.com/coders-app/coders-app-identity-server/pull/83#issuecomment-1441994680)

Ahora authenticateApp solo recibe targetApp y la keyToAuthenticate. Mira todos los hashes guardados para el targetApp y comprueba que al menos uno coincide con la keyToAuthenticate

checkApiKey solo recibe targetApp

He actualizado los tests y documentacion