### PR TITLE
Relocation of rule no-implicit-coercion

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -17,7 +17,6 @@ module.exports = {
         ],
         "@typescript-eslint/indent": "off",
         "@typescript-eslint/no-empty-function": "off",
-        "no-implicit-coercion": "off",
       },
     },
   ],
@@ -25,5 +24,7 @@ module.exports = {
     ecmaVersion: "latest",
     sourceType: "module",
   },
-  rules: {},
+  rules: {
+    "no-implicit-coercion": "off",
+  },
 };


### PR DESCRIPTION
Esta regla estaba anulada en los overrides de TS, pero XO no tiene esta regla en `eslint-config-xo-typescript` sino en `eslint-config-xo`, así que se ha pasado al objeto `rules` base.