### PR TITLE
Feature/cod 185 strict null checks configuration

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -17,6 +17,14 @@ module.exports = {
         ],
         "@typescript-eslint/indent": "off",
         "@typescript-eslint/no-empty-function": "off",
+        "@typescript-eslint/ban-types": [
+          "error",
+          {
+            types: {
+              null: false,
+            },
+          },
+        ],
       },
     },
   ],

--- a/src/checkApiKey/checkApiKey.test.ts
+++ b/src/checkApiKey/checkApiKey.test.ts
@@ -45,4 +45,16 @@ describe("Given the middleware returned from checkApiKey invoked with targetApp 
       expect(next).toHaveBeenCalledWith(invalidApiKeyError);
     });
   });
+
+  describe("When it receives a request with no api key nor app to authenticate ", () => {
+    test("Then it should invoke next with an error with message 'Invalid API key'", async () => {
+      const checkApiKeyMiddleware = checkApiKey(identityServer);
+
+      req.get = jest.fn().mockReturnValue(undefined);
+
+      await checkApiKeyMiddleware(req as Request, {} as Response, next);
+
+      expect(next).toHaveBeenCalledWith(invalidApiKeyError);
+    });
+  });
 });

--- a/src/checkApiKey/checkApiKey.ts
+++ b/src/checkApiKey/checkApiKey.ts
@@ -12,6 +12,10 @@ const checkApiKey =
     const appToAuthenticate = req.get(requestHeaders.apiName);
 
     try {
+      if (!appToAuthenticate || !apiKey) {
+        throw invalidApiKeyError;
+      }
+
       if (!(await authenticateApp(targetApp, appToAuthenticate, apiKey))) {
         throw invalidApiKeyError;
       }

--- a/src/loadEnvironments.ts
+++ b/src/loadEnvironments.ts
@@ -8,6 +8,11 @@ const {
   REDIS_PASSWORD: password,
 } = process.env;
 
+if (!port || !password || !host) {
+  console.error("Missing environmental variables");
+  process.exit(1);
+}
+
 export const environment = {
   redis: {
     host,

--- a/src/mocks/mockHashGet.ts
+++ b/src/mocks/mockHashGet.ts
@@ -6,10 +6,10 @@ const { apiGateway, identityServer } = appNames;
 const mockHashGet: (
   targetApp: string,
   appToAuthenticate: string
-) => string | undefined = jest
+) => string | null = jest
   .fn()
   .mockImplementation(
-    (targetApp: string, appToAuthenticate: string): string | undefined => {
+    (targetApp: string, appToAuthenticate: string): string | null => {
       if (targetApp === apiGateway && appToAuthenticate === identityServer) {
         return hashedKey;
       }

--- a/src/redis/getHash/getHash.ts
+++ b/src/redis/getHash/getHash.ts
@@ -3,7 +3,7 @@ import redis from "../redis.js";
 const getHash = async (
   targetApp: string,
   appToAuthenticate: string
-): Promise<string> => {
+): Promise<string | null> => {
   const hash = await redis.hget(targetApp, appToAuthenticate);
 
   return hash;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "outDir": "./build/" /* Specify an output folder for all emitted files. */,
     "noEmitOnError": true /* Disable emitting files if any type checking errors are reported. */,
     "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
-    "noImplicitAny": true /* Enable error reporting for expressions and declarations with an implied `any` type.. */
+    "noImplicitAny": true /* Enable error reporting for expressions and declarations with an implied `any` type.. */,
+    "strictNullChecks": true
   },
   "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
- Añadido `"strictNullChecks": true` en `tsconfig.json` 
- Añadido un guard que comprueba si faltan variables de entorno, dando un mensaje de feedback y cerrando el proceso si es así
- Quitado `null` de los tipos baneados por la norma de ban-types de ESLint
- Añadido `null` al tipado de `getHash` y su mock
- Añadido un guard en `checkApiKey` que comprueba si la request llega con los headers necesarios (`"X-API-NAME"` y `"X-API-KEY"`) y testeado
